### PR TITLE
Improve type capture.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,7 @@ export default {
 
   provideLinter: () => {
     const helpers = require("atom-linter");
-    const regex = "(?<file>.+):(?<line>\\d+):(?<col>\\d+): (?<type>.{5,9}):[ -]+(?<message>.*)";
+    const regex = "(?<file>.+):(?<line>\\d+):(?<col>\\d+): (?<type>[\\w \\-]{5,9}):[ -]+(?<message>.*)";
 
     // Read configuration data from JSON file .gcc-config.json
     // in project root


### PR DESCRIPTION
There was an issue with `linter-clang` and `linter-javac` where it would capture more text than the actual type. Thought it might be relevant here.