### PR TITLE
gfortran support - initial commit for review

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -48,20 +48,24 @@ module.exports.settings = function () {
       delete require.cache[config_file];
       var config_data = require(config_file);
       return {
-        execPath: config_data.execPath,
+        execCCPath: config_data.execCCPath,
+        execFCPath: config_data.execFCPath,
         gccIncludePaths: config_data.gccIncludePaths,
         gccSuppressWarnings: config_data.gccSuppressWarnings,
         gccDefaultCFlags: config_data.gccDefaultCFlags,
         gccDefaultCppFlags: config_data.gccDefaultCppFlags,
+        gccDefaultFortranFlags: config_data.gccDefaultFortranFlags,
         gccErrorLimit: config_data.gccErrorLimit
       };
   } else {
       return {
-          execPath: atom.config.get("linter-gcc.execPath"),
+          execCCPath: atom.config.get("linter-gcc.execCCPath"),
+          execFCPath: atom.config.get("linter-gcc.execFCPath"),
           gccIncludePaths: atom.config.get("linter-gcc.gccIncludePaths"),
           gccSuppressWarnings: atom.config.get("linter-gcc.gccSuppressWarnings"),
           gccDefaultCFlags: atom.config.get("linter-gcc.gccDefaultCFlags"),
           gccDefaultCppFlags: atom.config.get("linter-gcc.gccDefaultCppFlags"),
+          gccDefaultFortranFlags: atom.config.get("linter-gcc.gccDefaultFortranFlags"),
           gccErrorLimit: atom.config.get("linter-gcc.gccErrorLimit")
       };
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,11 +4,18 @@ CompositeDisposable = require('atom').CompositeDisposable;
 
 module.exports = {
   config: {
-    execPath: {
-      title: "GCC Executable Path",
-      description: "Note for Windows/Mac OSX users: please ensure that GCC is in your ```$PATH``` otherwise the linter might not work. If your path contains spaces, it needs to be enclosed in double quotes.",
+    execCCPath: {
+      title: "GCC C/C++ Compiler Executable Path",
+      description: "Note for Windows/Mac OSX users: please ensure that g++ is in your ```$PATH``` otherwise the linter might not work. If your path contains spaces, it needs to be enclosed in double quotes.",
       type: "string",
       default: "/usr/bin/g++",
+      order : 1
+    },
+    execFCPath: {
+      title: "GCC Fortran Compiler Executable Path",
+      description: "Note for Windows/Mac OSX users: please ensure that gfortran is in your ```$PATH``` otherwise the linter might not work. If your path contains spaces, it needs to be enclosed in double quotes.",
+      type: "string",
+      default: "/usr/bin/gfortran",
       order : 1
     },
     gccDefaultCFlags: {
@@ -23,6 +30,13 @@ module.exports = {
       description: "Supports the use of espcaped characters",
       type: "string",
       default: "-c -Wall -std=c++11",
+      order : 3
+    },
+    gccDefaultFortranFlags: {
+      title: "Fortran Flags",
+      description: "Supports the use of espcaped characters",
+      type: "string",
+      default: "-c -Wall -cpp",
       order : 3
     },
     gccIncludePaths: {
@@ -67,14 +81,19 @@ module.exports = {
 
   lint: function(editor, linted_file, real_file){
     const helpers=require("atom-linter");
-    const regex = "(.+):(?<line>\\d+):(?<col>\\d+):\\s*\\w*\\s*(?<type>(error|warning|note)):\\s*(?<message>.*)"
+    grammar_type = require("./utility").grammarType(editor.getGrammar().name)
+    if (grammar_type === "Fortran") {
+        regex = "(.+):(?<line>\\d+):(?<col>\\d+):(.|\\n|\\r|\\r\\n)*(?<type>(Error|Warning|Note)):\\s*(?<message>.*)"
+    } else {
+        regex = "(.+):(?<line>\\d+):(?<col>\\d+):\\s*\\w*\\s*(?<type>(error|warning|note)):\\s*(?<message>.*)"
+    }
     command = require("./utility").buildCommand(editor, linted_file);
     return helpers.exec(command.binary, command.args, {stream: "stderr"}).then(output => {
       msgs = helpers.parse(output, regex)
       msgs.forEach(function(entry){
         entry.filePath = real_file;
       })
-      if (msgs.length == 0 && output.indexOf("error") != -1){
+      if (msgs.length == 0 && output.toLowerCase().indexOf("error") != -1){
         msgs = [{
           type: 'error',
           text: output,

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -15,6 +15,8 @@ module.exports = {
       return "C";
     } else if (grammar_name.indexOf("C++") != -1) {
       return "C++";
+    } else if (grammar_name.indexOf("Fortran") != -1) {
+      return "Fortran";
     } else {
       return undefined;
     }
@@ -68,9 +70,18 @@ module.exports = {
       console.log("linter-gcc config: " + JSON.stringify(settings));
     }
 
-    cwd = module.exports.getCwd();
-    command = settings.execPath;
+    grammar_type = module.exports.grammarType(activeEditor.getGrammar().name);
 
+    if (grammar_type === "Fortran") {
+      execPath = settings.execFCPath;
+    } else if (grammar_type === "C") {
+      execPath = settings.execCCPath;
+    } else if (grammar_type === "C++") {
+      execPath = settings.execCCPath;
+    }
+    command = execPath
+
+    cwd = module.exports.getCwd();
     // Expand path if necessary
     if (command.substring(0, 1) == ".") {
       command = path.join(cwd, command);
@@ -81,20 +92,21 @@ module.exports = {
     if (!command) {
       atom.notifications.addError(
         "linter-gcc: Executable not found", {
-          detail: "\"" + settings.execPath + "\" not found"
+          detail: "\"" + execPath + "\" not found"
         }
       );
-      console.log("linter-gcc: \"" + settings.execPath + "\" not found");
+      console.log("linter-gcc: \"" + execPath + "\" not found");
       return;
     }
 
     args = [];
     var flags = "";
-    grammar_type = module.exports.grammarType(activeEditor.getGrammar().name);
     if (grammar_type === "C++") {
       flags = settings.gccDefaultCppFlags;
     } else if (grammar_type === "C") {
       flags = settings.gccDefaultCFlags;
+    } else if (grammar_type === "Fortran") {
+      flags = settings.gccDefaultFortranFlags;
     }
 
     var flag_array = module.exports.splitStringTrim(flags, " ", false, "");

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "split-string": "^0.1.0"
   },
   "package-deps": [
-    "linter"
+    "linter",
+    "language-fortran"
   ],
   "devDependencies": {
     "eslint": "latest"

--- a/spec/config-spec.js
+++ b/spec/config-spec.js
@@ -7,9 +7,11 @@ describe('Configuration function tests', () => {
 
   beforeEach(() => {
     waitsForPromise(() => {
-      atom.config.set('linter-gcc.execPath', '/usr/bin/g++')
+      atom.config.set('linter-gcc.execCCPath', '/usr/bin/g++')
+      atom.config.set('linter-gcc.execFCPath', '/usr/bin/gfortran')
       atom.config.set('linter-gcc.gccDefaultCFlags', '-Wall')
       atom.config.set('linter-gcc.gccDefaultCppFlags', '-Wall -std=c++11')
+      atom.config.set('linter-gcc.gccDefaultFortranFlags', '-Wall -cpp')
       atom.config.set('linter-gcc.gccErrorLimit', 15)
       atom.config.set('linter-gcc.gccIncludePaths', ' ')
       atom.config.set('linter-gcc.gccSuppressWarnings', true)
@@ -22,9 +24,11 @@ describe('Configuration function tests', () => {
     waitsForPromise(() => {
       return atom.workspace.open(__dirname + '/files/comment.cpp').then(() => {
           var config = settings()
-          expect(config.execPath).toEqual("/usr/bin/g++")
+          expect(config.execCCPath).toEqual("/usr/bin/g++")
+          expect(config.execFCPath).toEqual("/usr/bin/gfortran")
           expect(config.gccDefaultCFlags).toEqual("-Wall")
           expect(config.gccDefaultCppFlags).toEqual("-Wall -std=c++11")
+          expect(config.gccDefaultFortranFlags).toEqual("-Wall -cpp")
           expect(config.gccErrorLimit).toEqual(15)
           expect(config.gccIncludePaths).toEqual(" ")
           expect(config.gccSuppressWarnings).toEqual(true)
@@ -36,9 +40,11 @@ describe('Configuration function tests', () => {
     waitsForPromise(() => {
       return atom.workspace.open(__dirname + '/files/project_test/sub1/subsub1/file.cpp').then(() => {
           var config = settings()
-          expect(config.execPath).toEqual("exec_file")
+          expect(config.execCCPath).toEqual("exec_cc_file")
+          expect(config.execFCPath).toEqual("exec_fc_file")
           expect(config.gccDefaultCFlags).toEqual("cflags_file")
           expect(config.gccDefaultCppFlags).toEqual("cppflags_file")
+          expect(config.gccDefaultFortranFlags).toEqual("fortranflags_file")
           expect(config.gccErrorLimit).toEqual(1)
           expect(config.gccIncludePaths).toEqual("includepath_file")
           expect(config.gccSuppressWarnings).toEqual(true)
@@ -50,9 +56,11 @@ describe('Configuration function tests', () => {
     waitsForPromise(() => {
       return atom.workspace.open(__dirname + '/files/project_test/sub2/file.cpp').then(() => {
           var config = settings()
-          expect(config.execPath).toEqual("exec_subdir")
+          expect(config.execCCPath).toEqual("exec_cc_subdir")
+          expect(config.execFCPath).toEqual("exec_fc_subdir")
           expect(config.gccDefaultCFlags).toEqual("cflags_subdir")
           expect(config.gccDefaultCppFlags).toEqual("cppflags_subdir")
+          expect(config.gccDefaultFortranFlags).toEqual("fortranflags_subdir")
           expect(config.gccErrorLimit).toEqual(2)
           expect(config.gccIncludePaths).toEqual("includepath_subdir")
           expect(config.gccSuppressWarnings).toEqual(true)
@@ -64,9 +72,11 @@ describe('Configuration function tests', () => {
     waitsForPromise(() => {
       return atom.workspace.open(__dirname + '/files/project_test/sub2/file.cpp').then(() => {
           var config = settings()
-          expect(config.execPath).toEqual("exec_subdir")
+          expect(config.execCCPath).toEqual("exec_cc_subdir")
+          expect(config.execFCPath).toEqual("exec_fc_subdir")
           expect(config.gccDefaultCFlags).toEqual("cflags_subdir")
           expect(config.gccDefaultCppFlags).toEqual("cppflags_subdir")
+          expect(config.gccDefaultFortranFlags).toEqual("fortranflags_subdir")
           expect(config.gccErrorLimit).toEqual(2)
           expect(config.gccIncludePaths).toEqual("includepath_subdir")
           expect(config.gccSuppressWarnings).toEqual(true)
@@ -78,9 +88,11 @@ describe('Configuration function tests', () => {
     waitsForPromise(() => {
       return atom.workspace.open(__dirname + '/files/project_test/sub4/subsub2/file.cpp').then(() => {
           var config = settings()
-          expect(config.execPath).toEqual("exec_updir")
+          expect(config.execCCPath).toEqual("exec_cc_updir")
+          expect(config.execFCPath).toEqual("exec_fc_updir")
           expect(config.gccDefaultCFlags).toEqual("cflags_updir")
           expect(config.gccDefaultCppFlags).toEqual("cppflags_updir")
+          expect(config.gccDefaultFortranFlags).toEqual("fortranflags_updir")
           expect(config.gccErrorLimit).toEqual(5)
           expect(config.gccIncludePaths).toEqual("includepath_updir")
           expect(config.gccSuppressWarnings).toEqual(true)
@@ -93,9 +105,11 @@ describe('Configuration function tests', () => {
       return atom.workspace.open(__dirname + '/files/project_test').then( () => {
       return atom.workspace.open(__dirname + '/files/project_test/sub3/file.cpp').then( () => {
           var config = settings()
-          expect(config.execPath).toEqual("exec_project")
+          expect(config.execCCPath).toEqual("exec_cc_project")
+          expect(config.execFCPath).toEqual("exec_fc_project")
           expect(config.gccDefaultCFlags).toEqual("cflags_project")
           expect(config.gccDefaultCppFlags).toEqual("cppflags_project")
+          expect(config.gccDefaultFortranFlags).toEqual("fortranflags_project")
           expect(config.gccErrorLimit).toEqual(3)
           expect(config.gccIncludePaths).toEqual("includepath_project")
           expect(config.gccSuppressWarnings).toEqual(false)

--- a/spec/files/comment.f
+++ b/spec/files/comment.f
@@ -1,0 +1,3 @@
+* comment here
+      program main
+      end

--- a/spec/files/comment.f90
+++ b/spec/files/comment.f90
@@ -1,0 +1,3 @@
+! comment here
+program main
+end program

--- a/spec/files/error.f
+++ b/spec/files/error.f
@@ -1,0 +1,4 @@
+      program main
+      implicit none
+      i=1
+      end

--- a/spec/files/error.f90
+++ b/spec/files/error.f90
@@ -1,0 +1,4 @@
+program main
+implicit none
+i=1
+end program

--- a/spec/files/missing_include.f
+++ b/spec/files/missing_include.f
@@ -1,0 +1,4 @@
+#include "nonexistent"
+      program main
+      implicit none
+      end

--- a/spec/files/missing_include.f90
+++ b/spec/files/missing_include.f90
@@ -1,0 +1,4 @@
+#include "nonexistent"
+program main
+implicit none
+end program

--- a/spec/files/project_test/.gcc-flags.json
+++ b/spec/files/project_test/.gcc-flags.json
@@ -1,7 +1,9 @@
 {
-  "execPath": "exec_project",
+  "execCCPath": "exec_cc_project",
+  "execFCPath": "exec_fc_project",
   "gccDefaultCFlags": "cflags_project",
   "gccDefaultCppFlags": "cppflags_project",
+  "gccDefaultFortranFlags": "fortranflags_project",
   "gccErrorLimit": 3,
   "gccIncludePaths": "includepath_project",
   "gccSuppressWarnings": false

--- a/spec/files/project_test/sub1/subsub1/file.cpp.gcc-flags.json
+++ b/spec/files/project_test/sub1/subsub1/file.cpp.gcc-flags.json
@@ -1,7 +1,9 @@
 {
-  "execPath": "exec_file",
+  "execCCPath": "exec_cc_file",
+  "execFCPath": "exec_fc_file",
   "gccDefaultCFlags": "cflags_file",
   "gccDefaultCppFlags": "cppflags_file",
+  "gccDefaultFortranFlags": "fortranflags_file",
   "gccErrorLimit": 1,
   "gccIncludePaths": "includepath_file",
   "gccSuppressWarnings": true

--- a/spec/files/project_test/sub2/.gcc-flags.json
+++ b/spec/files/project_test/sub2/.gcc-flags.json
@@ -1,7 +1,9 @@
 {
-  "execPath": "exec_subdir",
+  "execCCPath": "exec_cc_subdir",
+  "execFCPath": "exec_fc_subdir",
   "gccDefaultCFlags": "cflags_subdir",
   "gccDefaultCppFlags": "cppflags_subdir",
+  "gccDefaultFortranFlags": "fortranflags_subdir",
   "gccErrorLimit": 2,
   "gccIncludePaths": "includepath_subdir",
   "gccSuppressWarnings": true

--- a/spec/files/project_test/sub4/.gcc-flags.json
+++ b/spec/files/project_test/sub4/.gcc-flags.json
@@ -1,7 +1,9 @@
 {
-  "execPath": "exec_updir",
+  "execCCPath": "exec_cc_updir",
+  "execFCPath": "exec_fc_updir",
   "gccDefaultCFlags": "cflags_updir",
   "gccDefaultCppFlags": "cppflags_updir",
+  "gccDefaultFortranFlags": "fortranflags_updir",
   "gccErrorLimit": 5,
   "gccIncludePaths": "includepath_updir",
   "gccSuppressWarnings": true

--- a/spec/linter-gcc-spec.js
+++ b/spec/linter-gcc-spec.js
@@ -7,9 +7,11 @@ describe('The GCC provider for AtomLinter', () => {
 
   beforeEach(() => {
     waitsForPromise(() => {
-      atom.config.set('linter-gcc.execPath', '/usr/bin/g++')
+      atom.config.set('linter-gcc.execCCPath', '/usr/bin/g++')
+      atom.config.set('linter-gcc.execFCPath', '/usr/bin/gfortran')
       atom.config.set('linter-gcc.gccDefaultCFlags', '-Wall')
       atom.config.set('linter-gcc.gccDefaultCppFlags', '-Wall -std=c++11')
+      atom.config.set('linter-gcc.gccDefaultFortranFlags', '-Wall -cpp')
       atom.config.set('linter-gcc.gccErrorLimit', 15)
       atom.config.set('linter-gcc.gccIncludePaths', ' ')
       atom.config.set('linter-gcc.gccSuppressWarnings', true)
@@ -42,9 +44,57 @@ describe('The GCC provider for AtomLinter', () => {
     })
   })
 
+  it('finds no errors in comment.f', () => {
+    waitsForPromise(() => {
+      filename = __dirname + '/files/comment.f'
+      return atom.workspace.open(filename).then(editor => {
+        main.lint(editor, editor.getPath(), editor.getPath()).then(function(){
+          var length = utility.flattenHash(main.messages).length
+          expect(length).toEqual(0);
+        })
+      })
+    })
+  })
+
+  it('finds no errors in comment.f90', () => {
+    waitsForPromise(() => {
+      filename = __dirname + '/files/comment.f90'
+      return atom.workspace.open(filename).then(editor => {
+        main.lint(editor, editor.getPath(), editor.getPath()).then(function(){
+          var length = utility.flattenHash(main.messages).length
+          expect(length).toEqual(0);
+        })
+      })
+    })
+  })
+
   it('finds one error in error.c', () => {
     waitsForPromise(() => {
       filename = __dirname + '/files/error.c'
+      return atom.workspace.open(filename).then(editor => {
+        main.lint(editor, editor.getPath(), editor.getPath()).then(function(){
+          var length = utility.flattenHash(main.messages).length
+          expect(length).toEqual(1);
+        })
+      })
+    })
+  })
+
+  it('finds one error in error.f', () => {
+    waitsForPromise(() => {
+      filename = __dirname + '/files/error.f'
+      return atom.workspace.open(filename).then(editor => {
+        main.lint(editor, editor.getPath(), editor.getPath()).then(function(){
+          var length = utility.flattenHash(main.messages).length
+          expect(length).toEqual(1);
+        })
+      })
+    })
+  })
+
+  it('finds one error in error.f90', () => {
+    waitsForPromise(() => {
+      filename = __dirname + '/files/error.f90'
       return atom.workspace.open(filename).then(editor => {
         main.lint(editor, editor.getPath(), editor.getPath()).then(function(){
           var length = utility.flattenHash(main.messages).length

--- a/spec/utility-spec.js
+++ b/spec/utility-spec.js
@@ -5,9 +5,11 @@ describe('Utility functions', () => {
 
   beforeEach(() => {
     waitsForPromise(() => {
-      atom.config.set('linter-gcc.execPath', '/usr/bin/g++')
+      atom.config.set('linter-gcc.execCCPath', '/usr/bin/g++')
+      atom.config.set('linter-gcc.execFCPath', '/usr/bin/gfortran')
       atom.config.set('linter-gcc.gccDefaultCFlags', '-Wall')
       atom.config.set('linter-gcc.gccDefaultCppFlags', '-Wall -std=c++11')
+      atom.config.set('linter-gcc.gccDefaultFortranFlags', '-Wall -cpp')
       atom.config.set('linter-gcc.gccErrorLimit', 15)
       atom.config.set('linter-gcc.gccIncludePaths', ' ')
       atom.config.set('linter-gcc.gccSuppressWarnings', true)
@@ -29,6 +31,22 @@ describe('Utility functions', () => {
   it('returns an editor for a C file', () => {
     waitsForPromise(() => {
       return atom.workspace.open(__dirname + '/files/missing_include.c').then(editor => {
+        expect(utility.getValidEditor(editor)).toBeDefined();
+      })
+    })
+  })
+
+  it('returns an editor for a Fortran - Fixed Form file', () => {
+    waitsForPromise(() => {
+      return atom.workspace.open(__dirname + '/files/missing_include.f').then(editor => {
+        expect(utility.getValidEditor(editor)).toBeDefined();
+      })
+    })
+  })
+
+  it('returns an editor for a Fortran - Free Form file', () => {
+    waitsForPromise(() => {
+      return atom.workspace.open(__dirname + '/files/missing_include.f90').then(editor => {
         expect(utility.getValidEditor(editor)).toBeDefined();
       })
     })

--- a/spec/utility-spec.js
+++ b/spec/utility-spec.js
@@ -15,6 +15,7 @@ describe('Utility functions', () => {
       atom.config.set('linter-gcc.gccSuppressWarnings', true)
       atom.config.set('linter-gcc.gccLintOnTheFly', false)
       atom.packages.activatePackage("language-c")
+      atom.packages.activatePackage("language-fortran")
       atom.packages.activatePackage("language-javascript")
       return atom.packages.activatePackage('linter-gcc')
     })


### PR DESCRIPTION
Hi,

this is a concept of how to add gfortran support to linter-gcc. I first tried to use linter-gfortran but that was so uncustomizable that I then decided to hack this linter-gcc to support gfortran as well. It works quite well so far for me, but since I have no javascript experience at all, most of this was copy-pasting and trial and error. So, this needs a thorough review. I must note that I have language-fortran installed for the tests.

Any feedback would be nice, especially:
- you think it is acceptable to add gfortran support to linter-gcc
- there are parts that need serious reworking

Steven