### PR TITLE
Added option to add file-relative include paths

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -27,7 +27,7 @@ module.exports = {
     },
     gccIncludePaths: {
       title: "GCC Include Paths",
-      description: "Enter your include paths as a comma-separated list. Paths starting with ```.``` or ```..``` are expanded relative to the project root/file path. If any of your paths contain spaces, they need to be enclosed in double quotes. To expand a directory recursively, add ```/*``` to the end of the path",
+      description: "Enter your include paths as a comma-separated list. Paths starting with ```.``` or ```..``` are expanded relative to the project root path and paths starting with a ```-``` are expanded relative to the path of the active file. If any of your paths contain spaces, they need to be enclosed in double quotes. To expand a directory recursively, add ```/*``` to the end of the path",
       type: "string",
       default: " ",
       order : 4

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -52,7 +52,19 @@ module.exports = {
     }
     return cwd;
   },
+  getFileDir: function() {
+    var filedir;
+    editor = atom.workspace.getActivePaneItem();
+    if (editor) {
+      temp_file = editor.buffer.file;
+      if (temp_file) {
+        filedir = temp_file.getParent().getPath();
+      }
+    }
+    return filedir;
+  },
   splitStringTrim: function(str, delim, expandPaths, itemPrefix){
+    var pathm = require("path");
     output = [];
     str = str.trim();
     if (str.length == 0){
@@ -63,7 +75,11 @@ module.exports = {
       item = item.trim();
       if (item.length > 0){
         if (item.substring(0, 1) == "." && expandPaths) {
-          item = require("path").join(cwd, item);
+          item = pathm.join(cwd, item);
+        }
+        else if (item.substring(0, 1) == "-" && expandPaths) {
+          item = item.substring(1, item.length);
+          item = pathm.join(module.exports.getFileDir(), item);
         }
         if (item.substring(item.length-2, item.length) == '/*' && expandPaths) {
           item = item.substring(0, item.length-2)


### PR DESCRIPTION
Hey first of all thanks for this project, it has already saved me a lot of time and is probably the best atom c++ linter out there :+1: 

I needed the option to give include paths relative to the currently editing file. At the moment one is not generally able to give include paths realtive to the current file if it is part of a bigger project, which can be really annoying.

So I added a check for pathnames starting with a "-" (dont know if this prefix ok, feel free to change it to whatever you like) to expand them relative to the current file.

Have to add that I am a total js noob, so if you want to include this feature (i would also understand if you do not see why it is needed) you should have a look at the code changes. I made only small changes and its working for me, though.
