### PR TITLE
Added Lint on-the-fly time interval option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,8 @@
 'use babel'
 
+time_last_lint = new Date().getTime()
+lint_waiting = false
+
 CompositeDisposable = require('atom').CompositeDisposable;
 
 module.exports = {
@@ -70,12 +73,19 @@ module.exports = {
       default: false,
       order : 10
     },
+    gccLintOnTheFlyInterval: {
+      title: "Lint on-the-fly Interval",
+      description: "Time interval (in ms) between linting",
+      type: "integer",
+      default: 300,
+      order : 11
+    },
     gccDebug: {
       title: "Show Debugging Messages",
       description: "Please read the linter-gcc wiki [here](https://github.com/hebaishi/linter-gcc/wiki) before reporting any issues.",
       type: "boolean",
       default: false,
-      order : 11
+      order : 12
     }
   },
 
@@ -125,6 +135,8 @@ module.exports = {
     );
     }
     require("atom-package-deps").install("linter-gcc");
+    time_last_lint = new Date().getTime()
+    lint_waiting = false
   },
   deactivate: function() {
     this.subscriptions.dispose()
@@ -140,10 +152,22 @@ module.exports = {
       editor = utility.getValidEditor(atom.workspace.getActiveTextEditor());
       if (!editor) return;
       if (atom.config.get("linter-gcc.gccLintOnTheFly") == false) return;
-      grammar_type = utility.grammarType(editor.getGrammar().name)
-      filename = String(module.exports.temp_file[grammar_type])
-      require('fs-extra').outputFileSync(filename, editor.getText());
-      module.exports.lint(editor, filename, editor.getPath());
+      if (lint_waiting) return;
+      lint_waiting = true
+      interval = atom.config.get("linter-gcc.gccLintOnTheFlyInterval")
+      time_now = new Date().getTime()
+      timeout = interval - (time_now - time_last_lint);
+      setTimeout(
+        function() {
+          time_last_lint = new Date().getTime()
+          lint_waiting = false
+          grammar_type = utility.grammarType(editor.getGrammar().name)
+          filename = String(module.exports.temp_file[grammar_type])
+          require('fs-extra').outputFileSync(filename, editor.getText());
+          module.exports.lint(editor, filename, editor.getPath());
+        },
+        timeout
+      );
     };
 
     lintOnSave = function(){


### PR DESCRIPTION
Hey, I was using this great linter with the "Lint on-the-fly" option enabled while coding an gtkmm application and then some problens occured.

In this application, there are some classes that uses gtk elements with various templates, then the gcc takes some time (2~3 seconds) to compile these clases.

While editing these classes, the linter is called multiple times before the first call ends, so it started to had multiple instances of gcc running at the same time, and so, after some time my computer starts lagging.

Then I created an config to set an interval, so the linter will not be called if it was already called inside this time interval.