### PR TITLE
prevent calling trim when compileCommandsfile == null

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -133,7 +133,7 @@ module.exports = {
     args = [];
     cwd = module.exports.getCwd();
     command = ""
-    if (settings.compileCommandsFile.trim() != "") {
+    if (settings.compileCommandsFile != null && settings.compileCommandsFile.trim() != "") {
       commands_file = settings.compileCommandsFile.trim()
       commands_file = commands_file.trim()
       if (commands_file.substring(0, 1) == ".") {
@@ -197,7 +197,7 @@ module.exports = {
       args.push(file);
     }
 
-    } 
+    }
     if (atom.config.get("linter-gcc.gccDebug")){
       full_command = "linter-gcc: " + command;
       args.forEach(function(entry) {


### PR DESCRIPTION
I have been having an annoying time using Atom on OS X since every time a file is saved the linter-gcc is executed and my 'settings.compileCommandsFile' is not defined causing an exception in the linter-gcc.
This PR fixes the issue for me.

`TypeError: Cannot read property 'trim' of undefined
    at Object.buildCommand (/Users/tmclane/.atom/packages/linter-gcc/lib/utility.js:136:37)
    at Object.lint (/Users/tmclane/.atom/packages/linter-gcc/lib/main.js:110:36)
    at lintOnSave (/Users/tmclane/.atom/packages/linter-gcc/lib/main.js:191:22)
    at Function.module.exports.Emitter.simpleDispatch (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/event-kit/lib/emitter.js:25:14)
    at Emitter.module.exports.Emitter.emit (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/event-kit/lib/emitter.js:129:28)
    at TextBuffer.module.exports.TextBuffer.saveAs (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/text-buffer/lib/text-buffer.js:1144:27)
    at TextBuffer.module.exports.TextBuffer.save (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/text-buffer/lib/text-buffer.js:1114:19)
    at TextEditor.module.exports.TextEditor.save (/Applications/Atom.app/Contents/Resources/app.asar/src/text-editor.js:904:26)
    at Pane.module.exports.Pane.saveItem (/Applications/Atom.app/Contents/Resources/app.asar/src/pane.js:738:18)
    at Pane.saveItem (/Applications/Atom.app/Contents/Resources/app.asar/src/pane.js:3:59)
    at Pane.module.exports.Pane.saveActiveItem (/Applications/Atom.app/Contents/Resources/app.asar/src/pane.js:721:19)
    at Workspace.module.exports.Workspace.saveActivePaneItem (/Applications/Atom.app/Contents/Resources/app.asar/src/workspace.js:693:35)
    at atom-workspace.core:save (/Applications/Atom.app/Contents/Resources/app.asar/src/register-default-commands.js:225:32)
    at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:259:29)
    at /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:3:59
    at KeymapManager.module.exports.KeymapManager.dispatchCommandEvent (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:587:16)
    at KeymapManager.module.exports.KeymapManager.handleKeyboardEvent (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:382:22)
    at WindowEventHandler.module.exports.WindowEventHandler.handleDocumentKeyEvent (/Applications/Atom.app/Contents/Resources/app.asar/src/window-event-handler.js:106:36)
    at HTMLDocument.<anonymous> (/Applications/Atom.app/Contents/Resources/app.asar/src/window-event-handler.js:3:59)
`
