### PR TITLE
Add support for multiple projects, fix linting when cross-compiling with cmake

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,15 +13,15 @@ module.exports.settings = function () {
   var file_settings = atom.workspace.getActiveTextEditor().getPath() + SETTINGS_FILENAME;
   var directory_settings = path.join(path.dirname(file_settings), SETTINGS_FILENAME);
   var config_file = "";
-
+  var project_id = require("./utility").guessProjectId();
   if (fs.existsSync(file_settings)) {
       config_file = file_settings;
   } else if (fs.existsSync(directory_settings)) {
       config_file = directory_settings;
   }
 
-  if (config_file == "" && atom.project.getPaths()[0] != undefined) {
-      var project_path = atom.project.getPaths()[0];
+  if (config_file == "" && atom.project.getPaths()[project_id] != undefined) {
+      var project_path = atom.project.getPaths()[project_id];
       var current_path = path.dirname(file_settings);
       var current_file = "";
       var counter = 0;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -179,8 +179,11 @@ module.exports = {
         } catch (e) {
           console.log(e)
         }
-      }
+    }
+      /* Only override command from settings if compile_commands.json didn't provide one */
+      if (command == "")
         command = settings.execPath;
+
       // Expand path if necessary
       if (command.substring(0, 1) == ".") {
         command = path.join(cwd, command);

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -40,8 +40,30 @@ module.exports = {
     }
     return editor;
   },
+  guessProjectId: function()
+  {
+    var file_settings = atom.workspace.getActiveTextEditor().getPath()
+    var num = 0;
+    var totalGuesses = 0
+    atom.project.getPaths().forEach(function(item, i, arr) {
+        if (file_settings.indexOf(item) == 0) {
+          num = i;
+          totalGuesses++;
+          console.log("Guessed active project id: " + i + " path: " + item)
+        }
+    })
+
+    if (totalGuesses > 1) {
+      atom.notifications.addWarning(
+        "linter-gcc: More than one open project contain file: "
+        + file_settings
+        + "This is confusing for the linter. Perhaps you need to close a few projects?")
+    }
+    return num;
+  },
   getCwd: function() {
-    var cwd = atom.project.getPaths()[0]
+    var id = this.guessProjectId()
+    var cwd = atom.project.getPaths()[id]
     if (!cwd) {
       editor = atom.workspace.getActivePaneItem();
       if (editor) {


### PR DESCRIPTION
This two commits fix a few nasty bugs in linter-gcc: 

- First one adds the required guesswork to find out the active project, thus fixes #111. If there are multiple folders containing the same file open - the plugin will show a warning.

- The second commit fixes erroneous behavior when the compiler binary from compile_commands.json was always overridden  by the one from settings. (E.g. avr-gcc finally lints everything as it should)

