### PR TITLE
config: use atom defaults for missing local keys

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,7 @@ module.exports.settings = function () {
   var file_settings = atom.workspace.getActiveTextEditor().getPath() + SETTINGS_FILENAME;
   var directory_settings = path.join(path.dirname(file_settings), SETTINGS_FILENAME);
   var config_file = "";
+  var config = {};
 
   if (fs.existsSync(file_settings)) {
       config_file = file_settings;
@@ -43,6 +44,19 @@ module.exports.settings = function () {
       console.log("linter-gcc: Using configuration page settings");
     }
   }
+
+  config = {
+      execPath: atom.config.get("linter-gcc.execPath"),
+      gccIncludePaths: atom.config.get("linter-gcc.gccIncludePaths"),
+      gccSuppressWarnings: atom.config.get("linter-gcc.gccSuppressWarnings"),
+      gccDefaultCFlags: atom.config.get("linter-gcc.gccDefaultCFlags"),
+      gccDefaultCppFlags: atom.config.get("linter-gcc.gccDefaultCppFlags"),
+      gccErrorLimit: atom.config.get("linter-gcc.gccErrorLimit"),
+      gccErrorString: atom.config.get("linter-gcc.gccErrorString"),
+      gccWarningString: atom.config.get("linter-gcc.gccWarningString"),
+      gccNoteString: atom.config.get("linter-gcc.gccNoteString"),
+      compileCommandsFile: atom.config.get("linter-gcc.compileCommandsFile"),
+  };
   var commands_file = ""
   if (config_file != "") {
       delete require.cache[config_file];
@@ -52,31 +66,17 @@ module.exports.settings = function () {
       } else {
         commands_file = atom.config.get("linter-gcc.compileCommandsFile");
       }
-      return {
-        execPath: config_data.execPath,
-        gccIncludePaths: config_data.gccIncludePaths,
-        gccSuppressWarnings: config_data.gccSuppressWarnings,
-        gccDefaultCFlags: config_data.gccDefaultCFlags,
-        gccDefaultCppFlags: config_data.gccDefaultCppFlags,
-        gccErrorLimit: config_data.gccErrorLimit,
-        gccErrorString: config_data.gccErrorString,
-        gccWarningString: config_data.gccWarningString,
-        gccNoteString: config_data.gccNoteString,
-        compileCommandsFile: commands_file
-      };
-  } else {
-      return {
-          execPath: atom.config.get("linter-gcc.execPath"),
-          gccIncludePaths: atom.config.get("linter-gcc.gccIncludePaths"),
-          gccSuppressWarnings: atom.config.get("linter-gcc.gccSuppressWarnings"),
-          gccDefaultCFlags: atom.config.get("linter-gcc.gccDefaultCFlags"),
-          gccDefaultCppFlags: atom.config.get("linter-gcc.gccDefaultCppFlags"),
-          gccErrorLimit: atom.config.get("linter-gcc.gccErrorLimit"),
-          gccErrorString: atom.config.get("linter-gcc.gccErrorString"),
-          gccWarningString: atom.config.get("linter-gcc.gccWarningString"),
-          gccNoteString: atom.config.get("linter-gcc.gccNoteString"),
-          compileCommandsFile: atom.config.get("linter-gcc.compileCommandsFile"),
-      };
+      (config_data.execPath !== undefined) && (config.execPath = config_data.execPath);
+      (config_data.gccIncludePaths !== undefined) && (config.gccIncludePaths = config_data.gccIncludePaths);
+      (config_data.gccSuppressWarnings !== undefined) && (config.gccSuppressWarnings = config_data.gccSuppressWarnings);
+      (config_data.gccDefaultCFlags !== undefined) && (config.gccDefaultCFlags = config_data.gccDefaultCFlags);
+      (config_data.gccDefaultCppFlags !== undefined) && (config.gccDefaultCppFlags = config_data.gccDefaultCppFlags);
+      (config_data.gccErrorLimit !== undefined) && (config.gccErrorLimit = config_data.gccErrorLimit);
+      (config_data.gccErrorString !== undefined) && (config.gccErrorString = config_data.gccErrorString);
+      (config_data.gccWarningString !== undefined) && (config.gccWarningString = config_data.gccWarningString);
+      (config_data.gccNoteString !== undefined) && (config.gccNoteString = config_data.gccNoteString);
+      config.compileCommandsFile = commands_file;
   }
 
+  return config;
 };


### PR DESCRIPTION
When using a local config in projects, the linter assumes every key is
defined and has a value. Especially if "execPath" is not set in the
local config, linter-gcc trips and produces stack traces like the one
listed in #138. Fix things by loading the global Atom first and
replacing keys set via a local config afterwards.